### PR TITLE
Lombok

### DIFF
--- a/src/main/java/ru/netology/domain/Radio.java
+++ b/src/main/java/ru/netology/domain/Radio.java
@@ -87,3 +87,4 @@ public class Radio {
         this.currentChannel = currentChannel;
     }
 }
+

--- a/src/test/java/ru/netology/domain/RadioTest.java
+++ b/src/test/java/ru/netology/domain/RadioTest.java
@@ -7,157 +7,141 @@ import static org.junit.jupiter.api.Assertions.assertEquals;
 class RadioTest {
 
     @Test
-    public void desiredChannel() {
+    public void noArgsAllByDefault() {
+        Radio radio = new Radio();
+        //увеличим на два, уменьшим на один, в итоге плюс 1 к громкости по умолчанию (0)
+        radio.increaseVolume();
+        radio.increaseVolume();
+        radio.decreaseVolume();
+        //увеличим на три, уменьшим на один, в итоге плюс два к каналу по умолчанию (0)
+        radio.increaseChannel();
+        radio.increaseChannel();
+        radio.increaseChannel();
+        radio.decreaseChannel();
+        assertEquals(1, radio.getCurrentVolume());
+        assertEquals(2, radio.getCurrentChannel());
+        assertEquals(9, radio.getMaxChannel());
+        assertEquals(0, radio.getMinChannel());
+        assertEquals(100, radio.getMaxVolume());
+        assertEquals(0, radio.getMinVolume());
+    }
+
+    @Test
+    public void noArgsTurnUpVolumeFromAboveMax() {
         Radio radio = new Radio();
         radio.setCurrentChannel(5);
+        radio.setCurrentVolume(1000);
+        radio.increaseVolume();
+        assertEquals(100, radio.getCurrentVolume());
+        assertEquals(100, radio.getMaxVolume());
         assertEquals(5, radio.getCurrentChannel());
+        assertEquals(9, radio.getMaxChannel());
+        assertEquals(0, radio.getMinChannel());
+        assertEquals(0, radio.getMinVolume());
     }
 
     @Test
-    // принесли пульт с возможностью ввода многозначных и отрицательных номеров каналов
-    public void desiredChannelNNN() {
-        Radio radio = new Radio();
-        radio.setCurrentChannel(500);
-        assertEquals(9, radio.getCurrentChannel());
-    }
-
-    @Test
-    // принесли пульт с возможностью ввода многозначных и отрицательных номеров каналов
-    public void desiredChannelMinusNNN() {
-        Radio radio = new Radio();
-        radio.setCurrentChannel(-500);
-        assertEquals(0, radio.getCurrentChannel());
-    }
-
-    @Test
-    public void nextChannel() {
+    public void noArgsTurnUpVolumeFromMax() {
         Radio radio = new Radio();
         radio.setCurrentChannel(5);
-        radio.increaseChannel();
-        assertEquals(6, radio.getCurrentChannel());
-    }
-
-    @Test
-    // принесли пульт с возможностью ввода многозначных и отрицательных номеров каналов
-    public void nextChannelFromNNN() {
-        Radio radio = new Radio();
-        radio.setCurrentChannel(500);
-        radio.increaseChannel();
-        assertEquals(0, radio.getCurrentChannel());
-    }
-
-    @Test
-    // принесли пульт с возможностью ввода многозначных и отрицательных номеров каналов
-    public void nextChannelFromMinusNNN() {
-        Radio radio = new Radio();
-        radio.setCurrentChannel(-500);
-        radio.increaseChannel();
-        assertEquals(1, radio.getCurrentChannel());
-    }
-
-    @Test
-    public void nextChannelFromMaxChannel() {
-        Radio radio = new Radio();
-        radio.setCurrentChannel(9);
-        radio.increaseChannel();
-        assertEquals(0, radio.getCurrentChannel());
-    }
-
-    @Test
-    public void previousChannel() {
-        Radio radio = new Radio();
-        radio.setCurrentChannel(5);
-        radio.decreaseChannel();
-        assertEquals(4, radio.getCurrentChannel());
-    }
-
-    @Test
-    // принесли пульт с возможностью ввода многозначных и отрицательных номеров каналов
-    public void previousChannelFromNNN() {
-        Radio radio = new Radio();
-        radio.setCurrentChannel(500);
-        radio.decreaseChannel();
-        assertEquals(8, radio.getCurrentChannel());
-    }
-
-    @Test
-    // принесли пульт с возможностью ввода многозначных и отрицательных номеров каналов
-    public void previousChannelFromMinusNNN() {
-        Radio radio = new Radio();
-        radio.setCurrentChannel(-500);
-        radio.decreaseChannel();
-        assertEquals(9, radio.getCurrentChannel());
-    }
-
-    @Test
-    public void previousChannelFromMinChannel() {
-        Radio radio = new Radio();
-        radio.setCurrentChannel(0);
-        radio.decreaseChannel();
-        assertEquals(9, radio.getCurrentChannel());
-    }
-
-    @Test
-    public void increaseVolume() {
-        Radio radio = new Radio();
-        radio.setCurrentVolume(4);
+        radio.setCurrentVolume(100);
         radio.increaseVolume();
-        assertEquals(5, radio.getCurrentVolume());
+        assertEquals(100, radio.getCurrentVolume());
+        assertEquals(100, radio.getMaxVolume());
+        assertEquals(5, radio.getCurrentChannel());
+        assertEquals(9, radio.getMaxChannel());
+        assertEquals(0, radio.getMinChannel());
+        assertEquals(0, radio.getMinVolume());
     }
 
     @Test
-    public void increaseVolumeFromNNN() {
+    public void noArgsTurnDownVolumeFromBelowMin() {
         Radio radio = new Radio();
-        radio.setCurrentVolume(500);
-        radio.increaseVolume();
-        assertEquals(10, radio.getCurrentVolume());
+        radio.setCurrentVolume(-100);
+        radio.decreaseVolume();
+        assertEquals(0, radio.getCurrentVolume());
+        assertEquals(0, radio.getMinVolume());
+    }
+
+        @Test
+        public void noArgsTurnDownVolumeFromMin() {
+            Radio radio = new Radio();
+            radio.setCurrentVolume(0);
+            radio.decreaseVolume();
+            assertEquals(0, radio.getCurrentVolume());
+            assertEquals(0, radio.getMinVolume());
+        }
+
+    @Test
+    public void noArgsTurnDownVolumeFromAboveMax() {
+        Radio radio = new Radio();
+        radio.setCurrentVolume(1000);
+        radio.decreaseVolume();
+        assertEquals(99, radio.getCurrentVolume());
+        assertEquals(100, radio.getMaxVolume());
     }
 
     @Test
-    public void increaseVolumeFromMinusNNN() {
+    public void noArgsTurnUpVolumeFromBelowMin() {
         Radio radio = new Radio();
-        radio.setCurrentVolume(-500);
+        radio.setCurrentVolume(-100);
         radio.increaseVolume();
         assertEquals(1, radio.getCurrentVolume());
+        assertEquals(0, radio.getMinVolume());
     }
 
     @Test
-    public void increaseVolumeFromMaxVolume() {
-        Radio radio = new Radio();
-        radio.setCurrentVolume(10);
-        radio.increaseVolume();
-        assertEquals(10, radio.getCurrentVolume());
-    }
-
-    @Test
-    public void decreaseVolume() {
-        Radio radio = new Radio();
-        radio.setCurrentVolume(4);
-        radio.decreaseVolume();
-        assertEquals(3, radio.getCurrentVolume());
-    }
-
-    @Test
-    public void decreaseVolumeFromNNN() {
-        Radio radio = new Radio();
-        radio.setCurrentVolume(500);
-        radio.decreaseVolume();
-        assertEquals(9, radio.getCurrentVolume());
-    }
-
-    @Test
-    public void decreaseVolumeFromMinusNNN() {
-        Radio radio = new Radio();
-        radio.setCurrentVolume(-500);
-        radio.decreaseVolume();
+    public void previousChannelFromAboveMax() {
+        Radio radio = new Radio(50, 0, 500);
+        radio.decreaseChannel();
+        assertEquals(50, radio.getCurrentChannel());
         assertEquals(0, radio.getCurrentVolume());
+        assertEquals(50, radio.getMaxChannel());
     }
 
     @Test
-    public void decreaseVolumeFromMinVolume() {
-        Radio radio = new Radio();
-        radio.setCurrentVolume(0);
-        radio.decreaseVolume();
+    public void nextChannelFromAboveMax() {
+        Radio radio = new Radio(50, 0, 500);
+        radio.increaseChannel();
+        assertEquals(0, radio.getCurrentChannel());
         assertEquals(0, radio.getCurrentVolume());
+        assertEquals(50, radio.getMaxChannel());
+    }
+
+    @Test
+    public void nextChannelFromMax() {
+        Radio radio = new Radio(50, 0, 50);
+        radio.increaseChannel();
+        assertEquals(0, radio.getCurrentChannel());
+        assertEquals(0, radio.getCurrentVolume());
+        assertEquals(50, radio.getMaxChannel());
+    }
+
+    @Test
+    public void nextChannelFromBelowMin() {
+        Radio radio = new Radio(100, 33, -100);
+        radio.increaseChannel();
+        assertEquals(0, radio.getCurrentChannel());
+        assertEquals(33, radio.getCurrentVolume());
+        assertEquals(100, radio.getMaxChannel());
+    }
+
+    @Test
+    public void previousChannelFromBelowMin() {
+        Radio radio = new Radio(100, 33, -100);
+        radio.decreaseChannel();
+        assertEquals(100, radio.getCurrentChannel());
+        assertEquals(33, radio.getCurrentVolume());
+        assertEquals(100, radio.getMaxChannel());
+    }
+
+    @Test
+    public void previousChannelFromMin() {
+        Radio radio = new Radio(100, 33, 0);
+        radio.decreaseChannel();
+        assertEquals(100, radio.getCurrentChannel());
+        assertEquals(33, radio.getCurrentVolume());
+        assertEquals(100, radio.getMaxChannel());
     }
 }
+


### PR DESCRIPTION
Переписал data-class с использованием Lombok, поэкспериментировал с тестами для изучения плагина.

Не совсем удобный и понятный инструмент. Причины:

если нужен конструктор только для части полей, его все равно нужно писать самому, или использовать массу NoArgs-конструкторов (как и без Lombok);
часть методов, в явном виде использованных в тестах (например, setMaxChannel), в отчете JaCoCo указаны как непротестированные;
затруднительно обеспечить покрытие по бранчам, т.к. Lombok генерирует дополнительные ветки при компиляции, а на них, понятное дело, тесты не пишутся. Для то, чтобы JaCoCo не "ронял" сборку, указал COVEREDRATIO 30%.